### PR TITLE
Make `token` and `user` optional inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,6 @@ jobs:
 | ---------------- | ----------- | -------- | ------------- |
 | `meta_yaml_dir` | Path to the directory where the `meta.yaml` file with building instructions is located | Required | |
 | `python-version` | Python version of the built packages | Required | |
-| `token` | Anaconda token for the package uploading (more info [here](#Anaconda-token-as-GitHub-secret)) | Required |  |
 | `platform_host` | Build packages for the host platform | Optional | true |
 | `platform_all` | Build packages for all supported platforms | Optional | false |
 | `platform_linux-64` | Build a package for the platform: linux-64 | Optional | false |
@@ -250,6 +249,7 @@ jobs:
 | `upload` | Upload the built package to Anaconda. Setting to false is useful to test build correctness in CI | Optional | true |
 | `overwrite` |  Do not cancel the uploading if a package with the same name is found already in Anaconda | Optional | false |
 | `user` | Name of the Anaconda.org channel to upload the package to | Optional | |
+| `token` | Anaconda token for the package uploading (more info [here](#Anaconda-token-as-GitHub-secret)) | Optional |  |
 | `label` | Label for the uploaded package (`main`, `dev`, ...) | Optional | main |
 
 They are placed in the `with:` subsection of the step where the `uibcdf/action-build-and-upload-conda-packages` action is used:
@@ -342,7 +342,6 @@ jobs:
           platform_osx-64: true
           platform_win-64: true
           upload: false
-          token: ${{ secrets.ANACONDA_TOKEN }} # Replace with the right name of your secret
 ```
 
 ## Other tools like this one

--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ inputs:
   user:
     description: Name of the Anaconda user or organization where the conda package will be published.
     required: false
-    dedault: ''
+    default: ''
   label:
     description: Label of the published conda package.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -98,6 +98,16 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Sanity checks on inputs
+      shell: bash
+      run: |
+        echo "::group::Sanity checks on inputs"
+        if [ "${{ inputs.upload }}" == "true" ] && [ "${{ inputs.token }}" == "" ]; then
+           echo -e "An Anaconda token is required when the package is to be uploaded.\n"\
+                    "Please specify a 'token', or set 'upload' to 'false'."
+           exit 1
+        fi
+        echo "::endgroup::"
     - name: Event trigger data
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,8 @@ inputs:
     default: false
   user:
     description: Name of the Anaconda user or organization where the conda package will be published.
-    required: true
+    required: false
+    dedault: ''
   label:
     description: Label of the published conda package.
     required: false
@@ -102,10 +103,16 @@ runs:
       shell: bash
       run: |
         echo "::group::Sanity checks on inputs"
-        if [ "${{ inputs.upload }}" == "true" ] && [ "${{ inputs.token }}" == "" ]; then
-           echo -e "An Anaconda token is required when the package is to be uploaded.\n"\
+        if [ "${{ inputs.upload }}" == "true" ]; then
+          if [ "${{ inputs.token }}" == "" ]; then
+            echo -e "An Anaconda token is required when the package is to be uploaded.\n"\
                     "Please specify a 'token', or set 'upload' to 'false'."
-           exit 1
+            exit 1
+          if [ "${{ inputs.user }}" == "" ]; then
+            echo -e "An Anaconda user or organization is required when the package is to be uploaded.\n"\
+                    "Please specify a 'user', or set 'upload' to 'false'."
+            exit 1
+          fi
         fi
         echo "::endgroup::"
     - name: Event trigger data

--- a/action.yml
+++ b/action.yml
@@ -83,9 +83,9 @@ inputs:
     description: Name of the Anaconda user or organization where the conda package will be published.
     required: true
   label:
-    description: Label of conda package published.
+    description: Label of the published conda package.
     required: false
-    default: auto
+    default: main
   token:
     description: Token to access to anaconda cloud.
     required: false
@@ -98,18 +98,17 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Getting release data
-      id: getting-release-data
+    - name: Event trigger data
       shell: bash
       run: |
-        echo "::group::Information of the trigger event"
-        echo "Trigger event and type: $GITHUB_EVENT_NAME, ${{github.event.action}}"
-        echo "Associated commit SHA and tag: $GITHUB_SHA, $GITHUB_REF"
+        echo "::group::Information about the trigger event"
+        echo "Trigger event: $GITHUB_EVENT_NAME"
+        echo "Associated commit SHA: $GITHUB_SHA"
         echo "::endgroup::"
     - name: Checking if meta.yaml is in meta_yaml_dir
       id: checking-meta_yaml
       shell: bash
-      working-directory: ./${{ inputs.meta_yaml_dir }}
+      working-directory: ${{ inputs.meta_yaml_dir }}
       run: |
         echo "::group::Checking if the file meta.yaml exists"
         if [ ! -f meta.yaml ]; then
@@ -122,7 +121,7 @@ runs:
     - name: Packages compilation
       id: packages-compilation
       shell: bash -l {0}
-      working-directory: ./${{ inputs.meta_yaml_dir }}
+      working-directory: ${{ inputs.meta_yaml_dir }}
       run: |
         echo "::group::Building conda package for host platform"
         out_dir=`mktemp -d -t compilation-XXXXXXXXXX`
@@ -213,24 +212,13 @@ runs:
       id: packages-uploading
       if: inputs.upload == 'true'
       shell: bash -l {0}
-      working-directory: ./${{ inputs.meta_yaml_dir }}
+      working-directory: ${{ inputs.meta_yaml_dir }}
       run: |
         echo "::group::Conda packages uploading"
-        #cd ${{ steps.packages-compilation.outputs.out_dir }}
         label=${{ inputs.label }}
         force=""
         if "${{ inputs.overwrite }}"; then
           force="--force"
-        fi
-        if [ "$label" == "auto" ]; then
-          if [ "${{github.event.action}}" == "released" ]; then
-             label="main"
-          elif [ "${{github.event.action}}" == "prereleased" ]; then
-             label="dev"
-          else
-             echo "The trigger type ${{github.event.action}} is not compatible with `label: auto`"
-             exit 1
-          fi
         fi
         export ANACONDA_API_TOKEN=${{ inputs.token }}
         SHORT_SHA="$(git rev-parse --short $GITHUB_SHA)"


### PR DESCRIPTION
Branched off #13.
**Please review/merge after #16 is reviewed/merged.**

Fixes #17.

- [x] Made `user` and `token` inputs optional (`token` was already option but the README said it was required. `user` was required but the README said it was optional).
- [x] Set sanity checks for inputs, including checks for `token` and `user` inputs when `upload` is set to `true`.
- [x] Updated README with correct information