### PR TITLE
Delete python input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,378 +1,425 @@
-# build-and-upload-conda-packages
+[conda-build-recipe]: https://docs.conda.io/projects/conda-build/en/stable/concepts/recipe.html
+[UIBCDF]: https://www.uibcdf.org/
+[anaconda.org]: https://anaconda.org/
+[GitHub workflow]: https://docs.github.com/en/actions/writing-workflows/about-workflows
+[conda-build-command]: https://docs.conda.io/projects/conda-build/en/stable/resources/commands/conda-build.html
+[conda-convert-command]: https://docs.conda.io/projects/conda-build/en/stable/resources/commands/conda-convert.html
+[anaconda-upload-command]: https://docs.anaconda.com/anaconda-repository/commandreference/#upload
+
+# action-build-and-upload-conda-packages
 [![Open Source Love](https://badges.frapsoft.com/os/v2/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-If a repository contains a `meta.yaml` file to build conda packages, the process of building and
-uploading packages to an Anaconda user or organization is automatized by this GitHub Action. The user has only to be sure that the repository [have access to the corresponding Anaconda token](#Requirements).
+:gear: **Build your conda package**<br>
+:arrows_counterclockwise: **Convert your conda package**<br>
+:rocket: **Upload your conda package**<br>
+:white_check_mark: **Completely automated!!**<br>
 
-In summary, this GitHub Action does the following:
+## Content
+- [About](#about)
+- [Requirements](#requirements)
+  - [Conda-build recipe](#conda-build-recipe)
+  - [Conda base environment](#conda-base-environment)
+  - [Anaconda token](#anaconda-token)
+    - [Create an Anaconda token](#create-an-anaconda-token)
+      - [Using the command line](#using-the-command-line)
+      - [Through the Anaconda.org website](#through-the-anacondaorg-website)
+    - [Add the Anaconda token to the GitHub Secrets](#add-the-anaconda-token-to-the-github-secrets)
+- [How to use](#how-to-use)
+- [Input parameters](#input-parameters)
+  - [Additional command line arguments](#additional-command-line-arguments)
+- [Outputs](#outputs)
+- [Examples](#examples)
+- [Acknowledgements](#acknowledgements)
 
-- It is suggested that the action is triggered by a release or a prerelease publication.
-- The action checks if the `meta.yaml` file exists in the directory specified by the user.
-- It compiles then the list of packages to the platform and Python version specified by the user.
-- Finally, the action uploads all packages built to the Anaconda user or organization specified by the user, with the label specified by the user (if no label is specified, the default label `main` is used).
-- The paths of the built packages are preserved as an [output](#outputs), to be passed to later jobs.
+## About
+This GitHub Action automates the process of building, converting, and uploading _Conda_ packages to [Anaconda.org]. It streamlines package distribution by handling:
 
-This GitHub Action was developed by [the Computational Biology and Drug Design Research Unit -UIBCDF- at the
-Mexico City Children's Hospital Federico Gómez](https://www.uibcdf.org/). Other GitHub Actions can
-be found at [the UIBCDF GitHub site](https://github.com/search?q=topic%3Agithub-actions+org%3Auibcdf&type=Repositories).
+- Building: Uses `conda build` to create _Conda_ packages from a [_conda-build_ recipe][conda-build-recipe].
+- Converting: Utilizes `conda convert` to generate platform-specific package variants.
+- Uploading: Publishes the final package versions to [Anaconda.org] for easy distribution.
+
+By integrating this action into your [CI/CD GitHub workflow][GitHub workflow], you can ensure that your _Conda_ packages are consistently built, transformed for multiple platforms, and made available to your users with minimal manual effort.
+
+This GitHub Action was originally developed by the [Computational Biology and Drug Design Research Unit (UIBCDF) at the
+Mexico City Children's Hospital Federico Gómez][UIBCDF]. For the complete list of contributors, refer to the [contributors section](https://github.com/uibcdf/action-build-and-upload-conda-packages/graphs/contributors).<br>
+Explore more GitHub Actions developed by UIBCDF at the [UIBCDF GitHub Organization page](https://github.com/search?q=topic%3Agithub-actions+org%3Auibcdf&type=Repositories).
 
 ## Requirements
 
-In addition to define the workflow to use this action in the '.github/workflow' directory of your
-repository. There are three things you have to solve: having an Anaconda token to authorize the
-access to your conda repository or organization, using Git tags as package version numbers in the metadata file with the conda build instructions, and a Yaml file to create a conda environment to
-work with conda-build.
+### Conda-build recipe
+A [conda-build recipe][conda-build-recipe] defines the instructions for building your package, primarily through a `meta.yaml` file, optionally accompanied by other supporting files.<br>
+These files can be placed within a `.conda` directory in your repository.<br>
+For details on how to structure a conda-build recipe, refer to the [_Conda_ metadata instructions](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html).
 
-### Anaconda token as GitHub secret
+### Conda base environment
+This action relies on `conda` commands, which must be accessible within the GitHub runner. To ensure this, a base [_Conda_ environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-file-manually) needs to be set up.<br>
+We recommend using the [conda-incubator/setup-miniconda](https://github.com/conda-incubator/setup-miniconda) action in a preceding step of your GitHub workflow to configure the _Conda_ base environment:
 
-In order to upload a package to your anaconda user or organization, you have to define an Anaconda API token. There are two ways you can easily do it. From the command line you can execute:
+```yaml
+steps:
+      ...
+      - name: Conda environment creation and activation
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: 
+          environment-file: path/to/conda/env.yaml # Path to the conda environment
+          auto-update-conda: false
+          auto-activate-base: false
+          show-channel-urls: true
+      ...      
+      - name: Build and upload the conda packages
+        uses: uibcdf/action-build-and-upload-conda-packages@v2.0.0
+        ...
+```
 
-```bash
-# In case of uploading to a user profile
+### Anaconda token
+
+In order to upload a package to your anaconda user or organization channel, you need to [create an Anaconda token](https://docs.anaconda.com/anacondaorg/user-guide/work-with-accounts/#generating-tokens).<br>
+
+#### Create an Anaconda token
+There are two main ways to create an Anaconda token:
+- [Using the command line](#using-the-command-line)
+- [Through the Anaconda.org website](#through-the-anacondaorg-website)
+  
+##### Using the command line
+You can create an Anaconda token from your terminal, using [anaconda auth](https://docs.anaconda.com/anaconda-repository/commandreference/#authentication):
+```
 # Replace 'MyToken' with the name you want for your token
-TOKEN=$(anaconda auth --create --name MyToken)
+anaconda auth --create --name MyToken
 ```
+> [!TIP]
+> To create token for an [Anaconda Organization](https://docs.anaconda.com/anacondaorg/user-guide/work-with-organizations/), add the `--org` option to the command above:
+> ```
+> # Replace 'MyOrg' with the name of the organization
+> # Replace 'MyToken' with the name you want for your token
+> anaconda auth --create --name MyToken --org MyOrg
+> ```
 
-or 
+##### Through the Anaconda.org website
+1. Log in to [Anaconda.org]
+2. From your profile in the top-right corner, select **Settings**.
+3. Click **Access** in the left-hand menu.
+4. Fill out the _Create access token_ form:
+   1. Provide a unique token name.
+   2. Set your token strength to `strong (longer token)`. This generates a strong, completely unique token that is difficult to guess with brute force methods.
+   3. Set the required scopes for your use case.
+   4. Set the expiration date.
+5. Click on _Create_
 
-```bash
-# Replace 'MyToken' with the name you want for your token
-# Replace 'MyOrg' with the name of your organization
-TOKEN=$(anaconda auth --create --name MyToken --org MyOrg)
-```
+<img src="create_token.png" alt="create token" width="60%">
 
-After that, You can access to the value of your token:
+> [!TIP]
+> To create a token for an [Anaconda Organization](https://docs.anaconda.com/anacondaorg/user-guide/work-with-organizations/), follow the steps outlined in [Issuing/reissuing a token](https://docs.anaconda.com/psm-cloud/tokens/#issuing-reissuing-a-token).
 
-```bash
-echo $TOKEN
-```
+#### Add the Anaconda token to the GitHub Secrets
+The best practice for using an Anaconda token in a GitHub Action is to store it as a [GitHub Secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions). This helps keep the token secure and prevents it from being exposed in workflow logs.<br>
+For instructions on creating and using GitHub Secrets, refer to [GitHub's documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions).
 
-There is another way to create and manage your tokens. You can do it with the web page of your
-Anaconda user or organization. In that page, the menu entrie 'Settings--> Access' shows the following form:
+## How to use
 
-<br>
-<center>
-<img src="create_token.png" width="60%">
-</center>
-<br>
+You can include this GitHub Action as a [step](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) within a [GitHub workflow], placed in the `.github/workflows` directory within your repository.
 
-In this form mark the option 'Allow write access to the API site', choose a name and an expiration date
-for your new token, and click 'Create'. Below this form, you will find the list of your tokens to
-view their value or remove them.
-
-Now, the last step. The repository where you want to include this GitHub Action has to have access,
-quietly, to the value of this token. But you have to protect it, including the token string
-explictly in the workflow is far from being a good idea. To solve this problem, GitHub includes for
-your GitHub repositories or organizations, the possibility to store
-['encrypted secrets'](https://github.blog/2021-04-13-implementing-least-privilege-for-secrets-in-github-actions/). [You can find documentation about it in the GitHub docs site](https://docs.github.com/en/actions/reference/encrypted-secrets). Let's see here how to store the Anaconda token accesible for any public repository of an organization. Look for the section 'Settings -> Secrets' in the organization main web page in GitHub and click on the button 'New organization scret'. Briefly, choose a new name -this way for the variable storing the token value in GitHub- and copy the value of your token (a long string of "random" characters). As you can see in the secret creation form, you can give access to all public repositories in the organization or just a selected set of them (also to your private ones depending on your plan).
-
-After all this process, **what matters to use this GitHub Action is the name of the secret with the
-Anaconda token value**.
-
-### Git Tag as package version
-
-The instructions to build the new conda packages are defined by means of a YAML file usually named
-`meta.yaml`. It is your work having this file well implemented. [Here you can find a guide to decide
-the building parameters in this file](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html).
-
-In this metadata file, the conda-build recipe includes setting the version number of the new
-package. To avoid adding it manually, use `{{ environ['GIT_DESCRIBE_TAG'] }}` in the `package: version:` field of the `meta.yaml` file. 
-Therefore, the first lines or your `meta.yaml` file should look like this:
+An example of the basic usage of this GitHub Action is displayed below:
 
 ```yaml
-package:
-  name: package_name # write your library name
-  version: "{{ environ['GIT_DESCRIBE_TAG'] }}"
-
-source:
-  path: ../../
-
-build:
-  number: 1
-```
-
-[Remember that version numbers including the dash character "-" are not supported by conda-build](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#package-version) as package versions. If you want to release a version like "1.0.0-beta.1", replace it with something like "1.0.0b1". Check [PEPE-86 verlib conventions](https://www.python.org/dev/peps/pep-0386/) for further details.
-
-### A Yaml file to create a conda environment to work with conda-build
-
-Building your conda packages requires dependencies that can be solved with a
-temporary conda environment. You already know that the list of dependencies of your library are specified in [your `meta.yaml` file with the compilation instructions](), but the required channels needed to find them need to be provided. In the case of this GitHub Action, these channels are taken from the Yaml file with the details to execute the packages compilation (see the section ["Documentation conda environment"](#Documentation-conda-environment)). This Yaml file will look like:
-
-```yaml
-channels:    # write here the list of channels to look for your library dependencies
-  - uibcdf
-  - conda-forge
-  - default
-
-dependencies:   # Keep this block with only these two packages
-  - anaconda-client
-  - conda-build
-```
-
-
-## How to use it
-
-To include this GitHub Action, put a Yaml file (named, for instance, `build_and_upload_conda_packages.yaml`) with the following content in the `.github/workflows` directory of your repository. 
-An example of the structure of your `build_and_upload_conda_packages.yaml` is shown below:
-
-```yaml
-
 name: Build and upload conda packages
 
 on:
-  release:
-    types: [released, prereleased]
-# workflow_dispatch:        # Un-comment line if you also want to trigger action manually
+  push:
+    branches: main
 
 jobs:
-  conda_deployment_with_new_tag:
-    name: Conda deployment of package with Python ${{ matrix.python-version }}
+  conda_deployment:
+    name: Conda deployment
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9, 3.10, 3.11]
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Checkout repo
+        uses: actions/checkout@v4
       - name: Conda environment creation and activation
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: ${{ matrix.python-version }}
-          environment-file: path/to/build/env.yaml    # Path to the build conda environment
+          python-version: 3.11
+          environment-file: path/to/conda/env.yaml    # Replace with the path to your conda environment
           auto-update-conda: false
           auto-activate-base: false
           show-channel-urls: true
-      - name: Set label
-        id: set-label
-        shell: bash
-        run: |
-          if [[ "${{ github.event.action }}" == "prereleased" ]]; then
-            label=dev
-          else
-            label=main
-          echo "label=$label" >> $GITHUB_OUTPUT
       - name: Build and upload the conda packages
-        uses: uibcdf/action-build-and-upload-conda-packages@v1.4.0
+        uses: uibcdf/action-build-and-upload-conda-packages@v2.0.0
         with:
-          meta_yaml_dir: path/to/meta_yaml/directory
-          python-version: ${{ matrix.python-version }} # Values previously defined in `matrix`
-          platform_linux-64: true
-          platform_osx-64: true
-          platform_win-64: true
-          label: ${{ steps.set-label.outputs.label }}
-          user: uibcdf # Replace with the right user
-          token: ${{ secrets.ANACONDA_TOKEN }} # Replace with the right name of your secret
+          meta_yaml_dir: path/to/meta.yaml/directory # Replace with the path to your meta.yaml directory
+          user: uibcdf # Replace with your Anaconda username (or an Anaconda organization username)
+          token: ${{ secrets.ANACONDA_TOKEN }} # Replace with the name of your Anaconda Token secret
 ```
 
-### Host platform package and conversion to other platforms
+## Input parameters
 
-When the package is built from a pure Python library, [`conda convert` can produce packages for a
-long list of platforms](https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html?highlight=platform#optional-converting-conda-package-for-other-platforms). Instead, if you have to build a package that contains compiled code, `conda
-convert` does not work and only the package for the host platform will be built. In this former
-case, if you want to produce packages for multiple platforms (for instance, 'linux-64', 'osx-64' and 'win-64`), you can use something like the following:
-
-```yaml
-
-name: Build and upload conda packages
-
-on:
-  release:
-    types: [released, prereleased]
-# workflow_dispatch:        # Un-comment line if you also want to trigger action manually
-
-jobs:
-  conda_deployment_with_new_tag:
-    name: Conda deployment of package for platform ${{ matrix.os }} with Python ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, 3.10, 3.11]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Conda environment creation and activation
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-          environment-file: path/to/build/env.yaml    # Path to the build conda environment
-          auto-update-conda: false
-          auto-activate-base: false
-          show-channel-urls: true
-      - name: Set label
-        id: set-label
-        shell: bash
-        run: |
-          if [[ "${{ github.event.action }}" == "prereleased" ]]; then
-            label=dev
-          else
-            label=main
-          echo "label=$label" >> $GITHUB_OUTPUT
-      - name: Build and upload the conda packages
-        uses: uibcdf/action-build-and-upload-conda-packages@v1.4.0
-        with:
-          meta_yaml_dir: path/to/meta_yaml/directory
-          python-version: ${{ matrix.python-version }} # Values previously defined in `matrix`
-          platform_linux-64: true
-          platform_osx-64: true
-          platform_win-64: true
-          label: ${{ steps.set-label.outputs.label }}
-          user: uibcdf # Replace with the right user
-          token: ${{ secrets.ANACONDA_TOKEN }} # Replace with the right name of your secret
-```
-> [!NOTE]
-> In this case, is likely that your `meta.yaml` file need [preprocessing selectors](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#preprocessing-selectors) to differenciate the build among the different platforms.
+| Name | Description | Required/Optional | Default value |
+| ---------------- | ----------- | -------- | ------------- |
+| `meta_yaml_dir` | Path to the directory where the `meta.yaml` file is located. | Required | |
+| `upload` | Upload the built package to Anaconda. If set to `false`, the built package will not be uploaded to Anaconda.org. | Optional | `true` |
+| `overwrite` |  Do not abort the uploading if a package with the same name is already present in the Anaconda channel. | Optional | `false` |
+| `mambabuild` | Uses [`conda mambabuild` command](https://boa-build.readthedocs.io/en/stable/mambabuild.html) to build the packages. Requires [`mamba` setup](https://github.com/conda-incubator/setup-miniconda?tab=readme-ov-file#example-6-mamba). | Optional | `false` |
+| `user` | Name of the Anaconda.org channel where the package will be uploaded. | Optional | |
+| `token` | [Anaconda token](#anaconda-token) for the package uploading. | Optional |  |
+| `label` | Label of the uploaded package. | Optional | `main` |
+| `platform_host` | Build packages for the host platform. | Optional | `true` |
+| `platform_all` | Build packages for all supported platforms. | Optional | `false` |
+| `platform_linux-64` | Build packages for the `linux-64` platform. | Optional | `false` |
+| `platform_linux-32` | Build packages for the `linux-32` platform. | Optional | `false` |
+| `platform_osx-64` | Build packages for the `osx-64` platform. | Optional | `false` |
+| `platform_osx-arm64` | Build packages for the `osx-arm64` platform. | Optional | `false` |
+| `platform_linux-ppc64` | Build packages for the `linux-ppc64` platform. | Optional | `false` |
+| `platform_linux-ppc64le` | Build packages for the `linux-ppc64le` platform. | Optional | `false` |
+| `platform_linux-s390x` | Build packages for the `linux-s390x` platform. | Optional | `false` |
+| `platform_linux-armv6l` | Build packages for the `linux-armv6l` platform. | Optional | `false` |
+| `platform_linux-armv7l` | Build packages for the `linux-armv7l` platform. | Optional | `false` |
+| `platform_linux-aarch64` | Build packages for the `linux-aarch64` platform. | Optional | `false` |
+| `platform_win-32` | Build packages for the `linux-win-32` platform. | Optional | `false` |
+| `platform_win-64` | Build packages for the `linux-win-64` platform. | Optional | `false` |
+| `conda_build_args` | [Additional command line arguments](#additional-command-line-arguments) to pass to the `conda build` command. | Optional |  |
+| `conda_convert_args` | [Additional command line arguments](#additional-command-line-arguments) to pass to the `conda convert` command. | Optional |  |
+| `anaconda_upload_args` | [Additional command line arguments](#additional-command-line-arguments) to pass to the `anaconda upload` command. | Optional |  |
 
 ### Additional command line arguments
 This action, internally, calls the following commands:
-- [`conda build`](https://docs.conda.io/projects/conda-build/en/stable/resources/commands/conda-build.html) (or `conda mambabuild`, if `mambabuild` is set to `true`)
-- [`conda convert`](https://docs.conda.io/projects/conda-build/en/stable/resources/commands/conda-convert.html) (if any platform conversion is specified)
-- [`anaconda upload`](https://docs.anaconda.com/anaconda-repository/commandreference/#upload) (if `upload` is set to `true`)
+- [`conda build`][conda-build-command] (or `conda mambabuild`, if `mambabuild` is set to `true`)
+- [`conda convert`][conda-convert-command] (if any platform conversion is specified)
+- [`anaconda upload`][anaconda-upload-command] (if `upload` is set to `true`)
 
 The above commands have multiple command-line arguments that can be passed, for each of the respective command, by using the `conda_build_args`, `conda_convert_args` and `anaconda_upload_args` input parameters.
 
-For example, the `build_and_upload_conda_packages.yaml` file below builds a package with the `--override-chanels` and `--channel my_channel` `conda build` options, to avoid searching for a default or `.condarc` channel, but only looking at the specified channel. Furthermore, it also passes the `--show-imports` argument to the `conda convert` command, to show Python imports for the compiled parts of the package.
-
-```yaml
-
-name: Build and upload conda packages
-
-on:
-  release:
-    types: [released, prereleased]
-# workflow_dispatch:        # Un-comment line if you also want to trigger action manually
-
-jobs:
-  conda_deployment_with_new_tag:
-    name: Conda deployment of package with Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9, 3.10, 3.11]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Conda environment creation and activation
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-          environment-file: path/to/build/env.yaml    # Path to the build conda environment
-          auto-update-conda: false
-          auto-activate-base: false
-          show-channel-urls: true
-      - name: Set label
-        id: set-label
-        shell: bash
-        run: |
-          if [[ "${{ github.event.action }}" == "prereleased" ]]; then
-            label=dev
-          else
-            label=main
-          echo "label=$label" >> $GITHUB_OUTPUT
-      - name: Build and upload the conda packages
-        uses: uibcdf/action-build-and-upload-conda-packages@v1.4.0
-        with:
-          meta_yaml_dir: path/to/meta_yaml/directory
-          python-version: ${{ matrix.python-version }} # Values previously defined in `matrix`
-          platform_linux-64: true
-          platform_osx-64: true
-          platform_win-64: true
-          label: ${{ steps.set-label.outputs.label }}
-          user: uibcdf # Replace with the right user
-          token: ${{ secrets.ANACONDA_TOKEN }} # Replace with the right name of your secret
-          conda_build_args: --override-chanels --channel my_channel
-          conda_convert_args: --show-imports
-```
+Refer to the [Pass additional command-line arguments example](#pass-additional-command-line-arguments-example) for a practical case on the usage of these input parameters.
 
 > [!WARNING]
-> Some command line arguments in `conda_build_args`, `conda_convert_args` or `anaconda_upload_args` cannot be declared, as they are already used internally by the action, or if they clash with specific input parameters:
+> Some command line arguments in `conda_build_args`, `conda_convert_args` or `anaconda_upload_args` cannot be specified because they are either already handled internally by the action or conflict with specific input parameters:<br>
 > **`conda_build_args`**
 > - `--output-folder`
 > - `--no-anaconda-upload`
-> - `--python`
 > 
 > **`conda_convert_args`**
 > - `--output-folder`
 > 
 > **`anaconda_upload_args`**
-> - `--label`/`-l` together with `label` input
-> - `--user`/`-u` together with `user` input
-> - `--force` together with `overwrite` input
+> - `--label`/`-l` together with the `label` input parameter
+> - `--user`/`-u` together with the `user` input parameter
+> - `--force` together with the `overwrite` input parameter
 
-### Input parameters
-
-| Name | Description | Required/Optional | Default value |
-| ---------------- | ----------- | -------- | ------------- |
-| `meta_yaml_dir` | Path to the directory where the `meta.yaml` file with building instructions is located | Required | |
-| `python-version` | Python version of the built packages | Required | |
-| `upload` | Upload the built package to Anaconda. Setting to false is useful to test build correctness in CI | Optional | true |
-| `overwrite` |  Do not cancel the uploading if a package with the same name is found already in Anaconda | Optional | false |
-| `mambabuild` | Uses [boa (mambabuild)](https://boa-build.readthedocs.io/en/stable/mambabuild.html) to build the packages. | Optional | false |
-| `user` | Name of the Anaconda.org channel to upload the package to | Optional | |
-| `token` | Anaconda token for the package uploading (more info [here](#Anaconda-token-as-GitHub-secret)) | Optional |  |
-| `label` | Label for the uploaded package (`main`, `dev`, ...) | Optional | main |
-| `platform_host` | Build packages for the host platform | Optional | true |
-| `platform_all` | Build packages for all supported platforms | Optional | false |
-| `platform_linux-64` | Build a package for the platform: linux-64 | Optional | false |
-| `platform_linux-32` | Build a package for the platform: linux-32 | Optional | false |
-| `platform_osx-64` | Build a package for the platform: osx-64 | Optional | false |
-| `platform_osx-arm64` | Build a package for the platform: osx-arm64 | Optional | false |
-| `platform_linux-ppc64` | Build a package for the platform: linux-ppc64 | Optional | false |
-| `platform_linux-ppc64le` | Build a package for the platform: linux-ppc64le | Optional | false |
-| `platform_linux-s390x` | Build a package for the platform: linux-s390x | Optional | false |
-| `platform_linux-armv6l` | Build a package for the platform: linux-armv6l | Optional | false |
-| `platform_linux-armv7l` | Build a package for the platform: linux-armv7l | Optional | false |
-| `platform_linux-aarch64` | Build a package for the platform: linux-aarch64 | Optional | false |
-| `platform_win-32` | Build a package for the platform: linux-win-32 | Optional | false |
-| `platform_win-64` | Build a package for the platform: linux-win-64 | Optional | false |
-| `conda_build_args` | Command line arguments to pass to the `conda build` command. | Optional |  |
-| `conda_convert_args` | Command line arguments to pass to the `conda convert` command. | Optional |  |
-| `anaconda_upload_args` | Command line arguments to pass to the `anaconda upload` command. | Optional |  |
-
-They are placed in the `with:` subsection of the step where the `uibcdf/action-build-and-upload-conda-packages` action is used:
-
-```yaml
-      - name: Build and upload the conda packages
-        uses: uibcdf/action-build-and-upload-conda-packages@v1.4.0
-        with:
-          meta_yaml_dir: devtools/conda-build
-          python-version: ${{ matrix.python-version }} # Values previously defined in `matrix`
-          platform_linux-64: true
-          platform_osx-64: true
-          platform_win-64: true
-          user: uibcdf
-          label: dev
-          token: ${{ secrets.ANACONDA_TOKEN }}
-```
-
-At this point, you can probably wonder: but the python version of the package is specified in the
-`meta.yaml` file, isn't it?
-
-#### `python_version`
-
-To define the python versions of the packages created by the GitHub Action you should use the input parameter of [the workflow](#How-to-use-it) named `strategy: matrix: python-version`.
-
-```yaml
-    strategy:
-      matrix:
-        python-version: [3.9, 3.10, 3.11]
-```
-
-No matter the python version found in the `meta.yaml` file, this action will make all the work to
-convert the building instructions to the python versions you specify in your GitHub workflow.
-
-### Outputs
+## Outputs
 | Name | Description | 
 | --- | --- |
 | paths | Space-separated paths for the built packages, in the format `path1 path2 ... pathN`. |
 
-The output paths can be useful for later jobs, for example to make a release with the built packages as artifacs.
+The output paths can be useful for later jobs, for example to [create a GitHub release with the built packages as artifacs](#create-a-gitHub-release-with-the-built-packages-as-artifacs-example).
 
-### Testing build correctness
+## Examples
+
+<!-- Example 1 -->
+<details id="build-and-upload-a-package-when-a-new-git-tag-is-pushed-and-use-the-git-tag-as-the-package-version-example">
+<summary><b>Build and upload a package when a new <i>Git</i> tag is pushed and use the <i>Git</i> tag as the package version</b></summary>
+
+The `meta.yaml` file defines the [package version field](https://docs.conda.io/projects/conda-build/en/stable/resources/define-metadata.html#package-version) to specify the version number of the built package.<br>
+To automatically set the package version to the latest <i>Git</i> tag, [Jinja Templating](https://docs.conda.io/projects/conda-build/en/stable/resources/define-metadata.html#templating-with-jinja) can be used by setting the version value to `{{ GIT_DESCRIBE_TAG }}` in the `meta.yaml` file:
+```yaml
+# meta.yaml file
+package:
+  name: your_package_name # replace with your package name
+  version: {{ GIT_DESCRIBE_TAG }}
+```
+
+Then, to build and upload a package whenever a new <i>Git</i> tag is pushed, your workflow yaml file can look like the following:
+```yaml
+# your_worfklow.yaml file
+name: Build and upload conda packages when a tag gets pushed
+
+on:
+  push:
+    tags: 
+      - '*'
+
+jobs:
+  conda_deployment:
+    name: Conda deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+      - name: Conda environment creation and activation
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: 3.11
+          environment-file: path/to/conda/env.yaml    # Replace with the path to your conda environment
+          auto-update-conda: false
+          auto-activate-base: false
+          show-channel-urls: true
+      - name: Build and upload the conda packages
+        uses: uibcdf/action-build-and-upload-conda-packages@v2.0.0
+        with:
+          meta_yaml_dir: path/to/meta.yaml/directory # Replace with the path to your meta.yaml directory
+          user: uibcdf # Replace with your Anaconda username (or an Anaconda organization username)
+          token: ${{ secrets.ANACONDA_TOKEN }} # Replace with the name of your Anaconda Token secret
+```
+
+**:bulb:TIP**<br>
+Version numbers including the dash character `-` are [not supported by conda-build](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#package-version). If you want to release a version like `1.0.0-beta.1`, replace it with something like `1.0.0b1`.
+</details>
+
+<!-- Example 2 -->
+<details id="build-a-pure-python-conda-package-for-different-platforms-example">
+<summary><b>Build a <i>pure Python</i> conda package for different platforms</b></summary>
+
+When a package is built as pure Python library, `conda convert` can generate [packages for other platforms](https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html?highlight=platform#optional-converting-conda-package-for-other-platforms).<br>
+To create packages for multiple platforms (such as 'linux-64', 'osx-64' and 'win-64`), you can use the following workflow:
+
+```yaml
+# your_worfklow.yaml file
+name: Build and upload pure-python conda package for different platforms
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  conda_deployment:
+    name: Conda deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Conda environment creation and activation
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: 3.11
+          environment-file: path/to/conda/env.yaml    # Replace with the path to your conda environment
+          auto-update-conda: false
+          auto-activate-base: false
+          show-channel-urls: true
+      - name: Build and upload the conda packages
+        uses: uibcdf/action-build-and-upload-conda-packages@v2.0.0
+        with:
+          meta_yaml_dir: path/to/meta.yaml/directory # Replace with the path to your meta.yaml directory
+          user: uibcdf # Replace with your Anaconda username (or an Anaconda organization username)
+          token: ${{ secrets.ANACONDA_TOKEN }} # Replace with the name of your Anaconda Token secret
+          platform_linux-64: true
+          platform_osx-64: true
+          platform_win-64: true
+```
+</details>
+
+<!-- Example 3 -->
+<details id="build-a-platform-specific-conda-package-for-different-platforms-example">
+<summary><b>Build a platform-specific conda package for different platforms</b></summary>
+
+If a package requires platform-specific compilation instructions, `conda convert` is not a viable option.<br>
+Instead, the package can be built separately for each target platform by running multiple <i>Conda</i> builds in parallel using the [GitHub matrix strategy](https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow):
+
+```yaml
+# your_worfklow.yaml file
+name: Build and upload platform-specific conda packages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  conda_deployment:
+    name: Conda deployment
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Conda environment creation and activation
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: 3.11
+          environment-file: path/to/conda/env.yaml    # Replace with the path to your conda environment
+          auto-update-conda: false
+          auto-activate-base: false
+          show-channel-urls: true
+      - name: Build and upload the conda packages
+        uses: uibcdf/action-build-and-upload-conda-packages@v2.0.0
+        with:
+          meta_yaml_dir: path/to/meta.yaml/directory # Replace with the path to your meta.yaml directory
+          user: uibcdf # Replace with your Anaconda username (or an Anaconda organization username)
+          token: ${{ secrets.ANACONDA_TOKEN }} # Replace with the name of your Anaconda Token secret
+```
+This setup will run three jobs in parallel, building and uploading the Conda package for the `macos-latest`, `ubuntu-latest` and `windows-latest` platforms.
+
+**:bulb:TIP**<br>
+In this case, your `meta.yaml` file will likely need [preprocessing selectors](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#preprocessing-selectors) to differenciate builds across platforms.
+</details>
+
+<!-- Example 4 -->
+<details id="pass-additional-command-line-arguments-example">
+<summary><b>Pass additional command-line arguments</b></summary>
+
+To build a package and limit the search for dependencies to specific Anaconda channels, the `--override-channels` and `--channel my_channel` options can be passed to the to the [conda build][conda-build-command] command.
+
+Additionally, to display _Python_ imports for the compiled components of the built package, the `--show-imports` option can be passed to the [conda convert][conda-convert-command] command.
+
+To apply these options when building and uploading a package, you can use the following workflow:
+
+```yaml
+# your_worfklow.yaml file
+name: Build and upload conda packages with specific Anaconda channels and showing Python imports
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  conda_deployment:
+    name: Conda deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Conda environment creation and activation
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: 3.11
+          environment-file: path/to/conda/env.yaml    # Replace with the path to your conda environment
+          auto-update-conda: false
+          auto-activate-base: false
+          show-channel-urls: true
+      - name: Build and upload the conda packages
+        uses: uibcdf/action-build-and-upload-conda-packages@v2.0.0
+        with:
+          meta_yaml_dir: path/to/meta.yaml/directory # Replace with the path to your meta.yaml directory
+          user: uibcdf # Replace with your Anaconda username (or an Anaconda organization username)
+          token: ${{ secrets.ANACONDA_TOKEN }} # Replace with the name of your Anaconda Token secret
+          platform_osx-64: true
+          conda_build_args: --override-chanels --channel my_channel # Replace my_channel with the name of the specific channel
+          conda_convert_args: --show-imports
+```
+</details>
+
+<!-- Example 5 -->
+<details id="build-a-package-for-multiple-python-versions-example">
+<summary><b>Build a package for multiple <i>Python</i> versions</b></summary>
+</details>
+
+<!-- Example 6 -->
+<details id="build-a-package-for-multiple-python-versions-example">
+<summary><b>Set the package label depending on the release type</b></summary>
+</details>
+
+<!-- Example 7 -->
+<details id="create-a-gitHub-release-with-the-built-packages-as-artifacs-example">
+<summary><b>Create a GitHub release with the built packages as artifacs</b></summary>
+</details>
+
+<!-- Example 8 -->
+<details id="test-correctness-of-a-conda-build">
+<summary><b>Test correctness of a <i>Conda</i> build</b></summary>
 
 Typically this workflow is called in a deployment step, e.g. after a pull-request has succeeded and a new tag is added to the repository, or when a release is created. This means deployment generally occurs without checking if any errors to the build process were introduced in a pull request or code change.
 
@@ -423,18 +470,14 @@ jobs:
           platform_win-64: true
           upload: false
 ```
+</details>
 
-## Other tools like this one
+## Acknowledgements
 
-This GitHub Action was developed to solve a need of the [UIBCDF]((https://www.uibcdf.org/)). And to be used, additionally, as example of
-house-made GitHub Action for researchers and students in this lab.
+This GitHub Action was initially developed to address a specific need of the [UIBCDF] and serve as an example of an in-house GitHub Action for its researchers and students.
 
-Below, you can find a list of other tools in the market that carry out these same tasks. 
-We recognize and thank the work of their developers. Many of those GitHub Actions were used by us to learn how to set up our own one.
+We extend our gratitude to the developers of the following related GitHub Actions, whose work provided valuable insights and guidance in setting up our own.
 
-If you think that your GitHub Action should be mentioned here, fell free to open a PR with a new line.
-
-### Github Actions for Conda package build/deployment
 https://github.com/fdiblen/anaconda-action
 https://github.com/MichaelsJP/conda-package-publish-action
 https://github.com/Jegp/conda-package-publish-action

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,6 @@ inputs:
   meta_yaml_dir:
     description: Path to the directory in the repository where the meta.yaml file is located.
     required: true
-  python-version:
-    description: Python version of the package to be built.
-    required: true
   mambabuild:
     description: Using boa (mambabuild) to build the packages.
     required: false
@@ -136,11 +133,6 @@ runs:
                 "To retrieve the paths of the built packages, please refer to this action's 'paths' output."
             exit 1
         fi
-        if ${{ contains(inputs.conda_build_args, '--python') }}; then
-            echo -e "The '--python' option is not allowed in 'conda_build_args'.\n"\
-                "To build packages for a specific python version, please use this action's 'python-version' input instead."
-            exit 1
-        fi
         if ${{ contains(inputs.conda_convert_args, '--output-folder') }}; then
             echo -e "The destination folder for the converted packages is set internally and the '--output-folder' option is not allowed in 'conda_convert_args'.\n"
                 "To retrieve the paths of the built packages, please refer to this action's 'paths' output."
@@ -200,7 +192,7 @@ runs:
         else
           build_function="build"
         fi
-        conda_build_command="conda $build_function . --no-anaconda-upload --output-folder $out_dir --python ${{ inputs.python-version }} ${{ inputs.conda_build_args }}"
+        conda_build_command="conda $build_function . --no-anaconda-upload --output-folder $out_dir ${{ inputs.conda_build_args }}"
         echo "$conda_build_command"
         eval "$conda_build_command"
         HOST_PACKAGE=$(eval "$conda_build_command --output")


### PR DESCRIPTION
Fixes #15.
- [x] Removed 'python-version' from the action inputs
- [x] Updated and restructured README

Please don't mind the many force-pushes to the branch. I `git commit --amend` the same commit multiple times to test the README rendering directly on GitHub.

The README was highly restructured. 
I suggest you read it directly from the [rendered version](https://github.com/uibcdf/action-build-and-upload-conda-packages/tree/davide/delete_python_input?tab=readme-ov-file#action-build-and-upload-conda-packages) and add your  review in the code or comment to suggest changes.