### PR TITLE
Transmute packages from .conda to .tar.bz2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@
   - [Additional command line arguments](#additional-command-line-arguments)
 - [Outputs](#outputs)
 - [Examples](#examples)
+  - [Example 1: Use git tag as the package version](#build-and-upload-a-package-when-a-new-git-tag-is-pushed-and-use-the-git-tag-as-the-package-version-example)
+  - [Example 2: Build a pure Python package for different platforms](#build-a-pure-python-conda-package-for-different-platforms-example)
+  - [Example 3: Build a platform-specific package for different platforms](#build-a-platform-specific-conda-package-for-different-platforms-example)
+  - [Example 4: Pass additional conda-build/conda-convert/anaconda-upload command-line arguments](#pass-additional-command-line-arguments-example)
+  - [Example 5: Build a package for multiple Python versions](#build-a-package-for-multiple-python-versions-example)
+  - [Example 6: Set the package label based on the release type](#set-the-package-label-based-on-the-release-type-example)
+  - [Example 7: Create a GitHub release with the built packages as assets](#create-a-github-release-with-the-built-packages-as-assets-example)
+  - [Example 8: Test correctness of a conda build](#test-correctness-of-a-conda-build)
+  - [Example 9: Force upload of a conda package](#force-upload-of-a-conda-package)
 - [Acknowledgements](#acknowledgements)
 
 ## About
@@ -162,7 +171,6 @@ jobs:
 | ---------------- | ----------- | -------- | ------------- |
 | `meta_yaml_dir` | Path to the directory where the `meta.yaml` file is located. | Required | |
 | `upload` | Upload the built package to Anaconda. If set to `false`, the built package will not be uploaded to Anaconda.org. | Optional | `true` |
-| `overwrite` |  Do not abort the uploading if a package with the same name is already present in the Anaconda channel. | Optional | `false` |
 | `mambabuild` | Uses [`conda mambabuild` command](https://boa-build.readthedocs.io/en/stable/mambabuild.html) to build the packages. Requires [`mamba` setup](https://github.com/conda-incubator/setup-miniconda?tab=readme-ov-file#example-6-mamba). | Optional | `false` |
 | `user` | Name of the Anaconda.org channel where the package will be uploaded. | Optional | |
 | `token` | [Anaconda token](#anaconda-token) for the package uploading. | Optional |  |
@@ -207,20 +215,19 @@ Refer to the [Pass additional command-line arguments example](#pass-additional-c
 > **`anaconda_upload_args`**
 > - `--label`/`-l` together with the `label` input parameter
 > - `--user`/`-u` together with the `user` input parameter
-> - `--force` together with the `overwrite` input parameter
 
 ## Outputs
 | Name | Description | 
 | --- | --- |
 | paths | Space-separated paths for the built packages, in the format `path1 path2 ... pathN`. |
 
-The output paths can be useful for later jobs, for example to [create a GitHub release with the built packages as artifacs](#create-a-gitHub-release-with-the-built-packages-as-artifacs-example).
+The output paths can be useful for later jobs, for example to [create a GitHub release with the built packages as assets](#create-a-github-release-with-the-built-packages-as-assets-example).
 
 ## Examples
 
 <!-- Example 1 -->
 <details id="build-and-upload-a-package-when-a-new-git-tag-is-pushed-and-use-the-git-tag-as-the-package-version-example">
-<summary><b>Build and upload a package when a new <i>Git</i> tag is pushed and use the <i>Git</i> tag as the package version</b></summary>
+<summary><b>Example 1: Build and upload a package when a new <i>Git</i> tag is pushed and use the <i>Git</i> tag as the package version</b></summary>
 
 The `meta.yaml` file defines the [package version field](https://docs.conda.io/projects/conda-build/en/stable/resources/define-metadata.html#package-version) to specify the version number of the built package.
 
@@ -275,7 +282,7 @@ Version numbers including the dash character `-` are [not supported by conda-bui
 
 <!-- Example 2 -->
 <details id="build-a-pure-python-conda-package-for-different-platforms-example">
-<summary><b>Build a <i>pure Python</i> conda package for different platforms</b></summary>
+<summary><b>Example 2: Build a <i>pure Python</i> conda package for different platforms</b></summary>
 
 When a package is built as pure Python library, `conda convert` can generate [packages for other platforms](https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html?highlight=platform#optional-converting-conda-package-for-other-platforms).
 
@@ -319,7 +326,7 @@ jobs:
 
 <!-- Example 3 -->
 <details id="build-a-platform-specific-conda-package-for-different-platforms-example">
-<summary><b>Build a platform-specific conda package for different platforms</b></summary>
+<summary><b>Example 3: Build a platform-specific conda package for different platforms</b></summary>
 
 If a package requires platform-specific compilation instructions, `conda convert` is not a viable option.
 
@@ -368,9 +375,11 @@ In this case, your `meta.yaml` file will likely need [preprocessing selectors](h
 
 <!-- Example 4 -->
 <details id="pass-additional-command-line-arguments-example">
-<summary><b>Pass additional command-line arguments</b></summary>
+<summary><b>Example 4: Pass additional command-line arguments</b></summary>
 
-To build a package and limit the search for dependencies to specific Anaconda channels, the `--override-channels` and `--channel my_channel` options can be passed to the to the [conda build][conda-build-command] command.
+[Additional command-line arguments](#additional-command-line-arguments) can be passed to the `conda build`, `conda convert` and `anaconda upload` commands, internally called within this action. 
+
+For example, to build a package and limit the search for dependencies to specific Anaconda channels, the `--override-channels` and `--channel my_channel` options can be passed to the to the [conda build][conda-build-command] command.
 
 Additionally, to display _Python_ imports for the compiled components of the built package, the `--show-imports` option can be passed to the [conda convert][conda-convert-command] command.
 
@@ -414,7 +423,7 @@ jobs:
 
 <!-- Example 5 -->
 <details id="build-a-package-for-multiple-python-versions-example">
-<summary><b>Build a package for multiple <i>Python</i> versions</b></summary>
+<summary><b>Example 5: Build a package for multiple <i>Python</i> versions</b></summary>
 
 The recommended approach for building packages across different _Python_ versions is to use [build variants](https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#build-variants).
 
@@ -449,8 +458,8 @@ In this case, no changes are needed in the workflow file for this action. A setu
 </details>
 
 <!-- Example 6 -->
-<details id="build-a-package-for-multiple-python-versions-example">
-<summary><b>Set the package label depending on the release type</b></summary>
+<details id="set-the-package-label-based-on-the-release-type-example">
+<summary><b>Example 6: Set the package label based on the release type</b></summary>
 
 ```yaml
 name: Build and upload conda packages with label according to release type
@@ -494,8 +503,8 @@ jobs:
 </details>
 
 <!-- Example 7 -->
-<details id="create-a-gitHub-release-with-the-built-packages-as-artifacs-example">
-<summary><b>Create a GitHub release with the built packages as artifacs</b></summary>
+<details id="create-a-github-release-with-the-built-packages-as-assets-example">
+<summary><b>Example 7: Create a GitHub release with the built packages as assets</b></summary>
 
 ```yaml
 name: Build and upload conda packages and create GitHub release with built packages as artifacts
@@ -545,7 +554,7 @@ jobs:
 
 <!-- Example 8 -->
 <details id="test-correctness-of-a-conda-build">
-<summary><b>Test correctness of a <i>Conda</i> build</b></summary>
+<summary><b>Example 8: Test correctness of a <i>Conda</i> build</b></summary>
 
 You can use this action in a [CI/CD workflow](https://github.com/resources/articles/devops/ci-cd) to test for errors during the conda build and conversion process, without uploading the package to Anaconda.org.
 
@@ -582,6 +591,46 @@ jobs:
           upload: false
 ```
 </details>
+
+<!-- Example 9 -->
+<details id="force-upload-of-a-conda-package">
+<summary><b>Example 9: Force upload of a <i>Conda</i> package</b></summary>
+
+To force the package upload to Anaconda.org regardless of errors (within the `anaconda upload` command), we can pass the additional [`--force` command-line argument](https://docs.anaconda.com/anaconda-repository/commandreference/#upload:~:text=%2D%2Dforce%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Force%20a%20package%20upload%20regardless%20of%20errors) as a `anaconda_upload_args`:
+
+```yaml
+name: Build and upload conda packages (force upload)
+
+on:
+  push:
+    branches: main
+
+jobs:
+  conda_deployment:
+    name: Conda deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Conda environment creation and activation
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: 3.11
+          environment-file: path/to/conda/env.yaml    # Replace with the path to your conda environment
+          auto-update-conda: false
+          auto-activate-base: false
+          show-channel-urls: true
+      - name: Build and upload the conda packages
+        uses: uibcdf/action-build-and-upload-conda-packages@v2.0.0
+        with:
+          meta_yaml_dir: path/to/meta.yaml/directory # Replace with the path to your meta.yaml directory
+          user: uibcdf # Replace with your Anaconda username (or an Anaconda organization username)
+          token: ${{ secrets.ANACONDA_TOKEN }} # Replace with the name of your Anaconda Token secret
+          anaconda_upload_args: --force
+```
+
+</details>
+
 
 ## Acknowledgements
 

--- a/action.yml
+++ b/action.yml
@@ -72,10 +72,6 @@ inputs:
     description: Upload built package to anaconda
     required: false
     default: true
-  overwrite:
-    description: Do not cancel the uploading if a package with the same name is found already in Anaconda.
-    required: false
-    default: ''
   user:
     description: Name of the Anaconda user or organization where the conda package will be published.
     required: false
@@ -150,11 +146,6 @@ runs:
         fi
         if ${{ contains(inputs.anaconda_upload_args, '--token') }} && [ -n "${{ inputs.token }}" ]; then
             echo -e "Both the 'token' input and the '--token' option within 'anaconda_upload_args' were specified.\n"\
-                "Please only use one of them."
-            exit 1
-        fi
-        if ${{ contains(inputs.anaconda_upload_args, '--force') }} && [ -n "${{ inputs.overwrite }}" ]; then
-            echo -e "Both the 'overwrite' input and the '--force' option within 'anaconda_upload_args' were specified.\n"\
                 "Please only use one of them."
             exit 1
         fi
@@ -268,12 +259,9 @@ runs:
         echo "::group::Conda packages uploading"
         label=${{ inputs.label }}
         label=${label:-main} #If label is empty (input not provided), set it to 'main'
-        if [[ "${{ inputs.overwrite }}" == true ]]; then
-          force=--force
-        fi
         export ANACONDA_API_TOKEN=${{ inputs.token }}
         for package_path in ${{ steps.set-output-paths.outputs.paths }}; do
-          command="anaconda upload --user ${{ inputs.user }} $force --label $label ${{ inputs.anaconda_upload_args }} $package_path"
+          command="anaconda upload --user ${{ inputs.user }} --label $label ${{ inputs.anaconda_upload_args }} $package_path"
           echo "$command"
           eval "$command"
         done

--- a/action.yml
+++ b/action.yml
@@ -158,7 +158,6 @@ runs:
         echo "Associated commit SHA: $GITHUB_SHA"
         echo "::endgroup::"
     - name: Checking if meta.yaml is in meta_yaml_dir
-      id: checking-meta_yaml
       shell: bash -l {0}
       working-directory: ${{ inputs.meta_yaml_dir }}
       run: |
@@ -191,8 +190,41 @@ runs:
         echo "Package for host platform compiled as $HOST_PACKAGE"
         du -sh $HOST_PACKAGE
         echo "::endgroup::"
+    - name: Transmute .conda packages to .tar.bz2
+      id: transmutation
+      shell: bash -l {0}
+      env:
+        HOST_PACKAGE: ${{ steps.compilation.outputs.HOST_PACKAGE }}
+      run: |
+        # conda convert does not support .conda packages yet, therefore, we need to convert them 
+        # to .tar.bz2 first and then convert them back to .conda
+        # More info --> https://github.com/uibcdf/action-build-and-upload-conda-packages/issues/25
+        # Only perform transmutation if the package is a .conda package or conversion has been requested
+        echo "::group::Transmute .conda packages to .tar.bz2"
+        any_platform_inputs=$(jq 'to_entries | map(select(.key | startswith("platform_")) | .value == "true") | any' <<< '${{ toJSON(inputs) }}')
+        if [[ "${{ env.HOST_PACKAGE }}" == *.conda && (${{ contains(inputs.conda_convert_args, '-p ') }} == true || ${{ contains(inputs.conda_convert_args, '--platform ') }} == true || $any_platform_inputs == true) ]]; then
+          if ! command -v cph &> /dev/null; then # if cph is not installed, install it
+              echo "'conda-package-handling' is not installed. Installing it..."
+              conda install anaconda::conda-package-handling
+          fi
+          cph transmute ${{ env.HOST_PACKAGE }} .tar.bz2
+          host_package_tarfile=$(sed 's|.conda$|.tar.bz2|' <<< ${{ env.HOST_PACKAGE }})
+          echo "Transmuted '$(basename ${{ env.HOST_PACKAGE }})' to '$(basename $host_package_tarfile)'."
+        else
+          echo "No transmutation needed."
+          host_package_tarfile=
+        fi
+        echo "HOST_PACKAGE_TARFILE=$host_package_tarfile" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
+    - name: Packages conversion
+      id: conversion
+      shell: bash -l {0}
+      working-directory: ${{ inputs.meta_yaml_dir }}
+      env:
+        HOST_PACKAGE_TARFILE: ${{ steps.transmutation.outputs.HOST_PACKAGE_TARFILE }}
+        HOST_PACKAGE_ORIG: ${{ steps.compilation.outputs.HOST_PACKAGE }}
+      run: |
         echo "::group::Converting package for other platforms"
-        conda_convert_command="conda convert $HOST_PACKAGE -o $out_dir ${{ inputs.conda_convert_args }}"
         if "${{ inputs.platform_all }}"; then
           platforms_options+=" -p all"
         fi
@@ -232,13 +264,38 @@ runs:
         if "${{ inputs.platform_win-64 }}"; then
           platforms_options+=" -p win-64"
         fi
-        if [ -n "$platforms_options" ]; then
-            echo "${conda_convert_command}${platforms_options}"
-            eval "${conda_convert_command}${platforms_options}"
+        if [[ -n "$platforms_options" || ${{ contains(inputs.conda_convert_args, '-p ') }} == true || ${{ contains(inputs.conda_convert_args, '--platform ') }} == true ]]; then
+          if [[ -n "${{ env.HOST_PACKAGE_TARFILE }}" ]]; then
+            PACKAGE_FILE=${{ env.HOST_PACKAGE_TARFILE }}
+          else
+            PACKAGE_FILE=${{ env.HOST_PACKAGE_ORIG }}
+          fi
+          conda_convert_command="conda convert $PACKAGE_FILE -o ${{ steps.compilation.outputs.out_dir }} ${{ inputs.conda_convert_args }}"
+          echo "${conda_convert_command}${platforms_options}"
+          eval "${conda_convert_command}${platforms_options}"
+        else
+          echo "No package conversion requested."
         fi
         if ! "${{ inputs.platform_host }}"; then
-          rm $HOST_PACKAGE
+          rm ${{ steps.compilation.outputs.HOST_PACKAGE }}
           echo "Package for host platform removed."
+        fi
+        echo "::endgroup::"
+    - name: Transmute .tar.bz2 packages back to .conda
+      id: back-transmutation
+      shell: bash -l {0}
+      run: |
+        host_package_tarfile=${{ steps.transmutation.outputs.HOST_PACKAGE_TARFILE }}
+        echo "::group::Transmute packages back to '.conda' format"
+        if [[ -n "$host_package_tarfile" ]]; then
+          # find transmuted .tar.bz2 packages
+          transmuted_packages=$(find ${{ steps.compilation.outputs.out_dir }} -type f -name $(basename $host_package_tarfile))
+          for package_path in $transmuted_packages; do
+            cph transmute $package_path .conda
+          done
+          echo "Transmuted '$(basename $package_path)' packages back to '$(basename ${host_package_tarfile%.tar.bz2}).conda'."
+        else
+          echo "No transmutation needed."
         fi
         echo "::endgroup::"
     - name: Set output paths
@@ -250,8 +307,8 @@ runs:
         echo "Output paths set to: ${paths[@]}"
         echo "paths=${paths[@]}" >> $GITHUB_OUTPUT
         echo "::endgroup::"
-    - name: Packages uploading
-      id: uploading
+    - name: Packages upload
+      id: upload
       if: inputs.upload == 'true'
       shell: bash -l {0}
       working-directory: ${{ inputs.meta_yaml_dir }}

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,7 @@ inputs:
 outputs:
   paths:
     description: Paths for the built packages, in the format 'path1 path2 ... pathN'.
-    value: ${{steps.packages-uploading.outputs.paths}}
+    value: ${{steps.set-output-paths.outputs.paths}}
 
 runs:
   using: "composite"
@@ -180,7 +180,7 @@ runs:
         fi
         echo "::endgroup::"
     - name: Packages compilation
-      id: packages-compilation
+      id: compilation
       shell: bash -l {0}
       working-directory: ${{ inputs.meta_yaml_dir }}
       run: |
@@ -250,8 +250,17 @@ runs:
           echo "Package for host platform removed."
         fi
         echo "::endgroup::"
+    - name: Set output paths
+      id: set-output-paths
+      shell: bash -l {0}
+      run: |
+        echo "::group::Setting output paths"
+        paths=($(find ${{ steps.compilation.outputs.out_dir }} -type f -name $(basename ${{ steps.compilation.outputs.HOST_PACKAGE }})))
+        echo "Output paths set to: ${paths[@]}"
+        echo "paths=${paths[@]}" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
     - name: Packages uploading
-      id: packages-uploading
+      id: uploading
       if: inputs.upload == 'true'
       shell: bash -l {0}
       working-directory: ${{ inputs.meta_yaml_dir }}
@@ -263,14 +272,9 @@ runs:
           force=--force
         fi
         export ANACONDA_API_TOKEN=${{ inputs.token }}
-        SHORT_SHA="$(git rev-parse --short $GITHUB_SHA)"
-        package_paths=$(find ${{ steps.packages-compilation.outputs.out_dir }} -type f -name $(basename ${{ steps.packages-compilation.outputs.HOST_PACKAGE }}))
-        for package_path in $package_paths; do
+        for package_path in ${{ steps.set-output-paths.outputs.paths }}; do
           command="anaconda upload --user ${{ inputs.user }} $force --label $label ${{ inputs.anaconda_upload_args }} $package_path"
           echo "$command"
           eval "$command"
-          paths+=($package_path)
         done
-        echo "paths=${paths[@]}" >> $GITHUB_OUTPUT 
         echo "::endgroup::"
-


### PR DESCRIPTION
Fixes #25.
- [x] Split conversion and transmutations in standalone steps
- [x] Added transmutation step to convert .conda packages to .tar.bz2 format, before performing the conversion using 'conda convert'. Also added step to convert packages back to .conda format before uploading. 

This PR head branch is based on the `davide/remove_overwrite` branch. 
**Please review/merge after #34 is merged, and after rebasing to `main`**.