### PR TITLE
CI tests for the action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,6 +73,12 @@ jobs:
               osx-64/asyncio-3.4.1-py311_0.tar.bz2
               win-32/asyncio-3.4.1-py311_0.tar.bz2
               win-64/asyncio-3.4.1-py311_0.tar.bz2
+          - label: "Test: Remove host platform, anaconda_upload_args."
+            inputs: >-
+                "platform_host": false,
+                "anaconda_upload_args": --label mylabel
+            expected_num_outputs: 0
+            expected_outputs: ""
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,23 +6,46 @@ on:
   pull_request:
     branches: main
   workflow_dispatch:
+env:
+  CONDA_PKGS_DIRS: ~/conda_pkgs_dir
+defaults:
+  run:
+    shell: bash -l {0}
 
 jobs:
-  test-action:
+  setup-conda-build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v3
+    
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: 3.11
-          environment-file: ci/env.yml
-          miniconda-version: latest
-          auto-activate-base: false
-          auto-update-conda: false
-          show-channel-urls: true
-      - name: Test the action
+          environment-file: ci/environment.yml
+          cache-environment-key: environment-${{ hashFiles('ci/environment.yml') }}
+          cache-downloads-key: downloads-${{ hashFiles('ci/environment.yml') }}
+    
+      - name: Test
+        run: | 
+          conda-build --version
+          conda build --help
+
+  test-action:
+    runs-on: ubuntu-latest
+    needs: setup-conda-build
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: ci/environment.yml
+          cache-environment-key: environment-${{ hashFiles('ci/environment.yml') }}
+          cache-downloads-key: downloads-${{ hashFiles('ci/environment.yml') }}
+
+      - name: "Test 1: All platforms conversion"
         id: test-action
         uses: jenseng/dynamic-uses@v1 # Need this because github context is not supported within step.uses (https://github.com/actions/runner/issues/895)
         with: 
@@ -33,8 +56,9 @@ jobs:
                 "meta_yaml_dir": ci/asyncio_recipe,
                 "upload": false,
                 "platform_all": true,
-                "conda_build_args": "--package-format 2"
+                "conda_build_args": --package-format .conda
             }
+
       - name: Verify outputs
         env:
           EXPECTED_LENGTH: 13

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,32 @@ jobs:
   test-action:
     runs-on: ubuntu-latest
     needs: setup-conda-build
+    strategy:
+      matrix:
+        include:
+          - label: "Test: All platforms conversion, '.conda' package format"
+            inputs: >-
+              {
+                "meta_yaml_dir": ci/asyncio_recipe,
+                "upload": false,
+                "platform_all": true,
+                "conda_build_args": --package-format .conda
+              }
+            expected_num_outputs: 13
+            expected_outputs: >-
+              linux-32/asyncio-3.4.1-py311_0.conda
+              linux-64/asyncio-3.4.1-py311_0.conda
+              linux-aarch64/asyncio-3.4.1-py311_0.conda
+              linux-armv6l/asyncio-3.4.1-py311_0.conda
+              linux-armv7l/asyncio-3.4.1-py311_0.conda
+              linux-ppc64/asyncio-3.4.1-py311_0.conda
+              linux-ppc64le/asyncio-3.4.1-py311_0.conda
+              linux-s390x/asyncio-3.4.1-py311_0.conda
+              osx-64/asyncio-3.4.1-py311_0.conda
+              osx-arm64/asyncio-3.4.1-py311_0.conda
+              win-32/asyncio-3.4.1-py311_0.conda
+              win-64/asyncio-3.4.1-py311_0.conda
+              win-arm64/asyncio-3.4.1-py311_0.conda
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -45,37 +71,18 @@ jobs:
           cache-environment-key: environment-${{ hashFiles('ci/environment.yml') }}
           cache-downloads-key: downloads-${{ hashFiles('ci/environment.yml') }}
 
-      - name: "Test 1: All platforms conversion"
+      - name: ${{ matrix.label }}
         id: test-action
         uses: jenseng/dynamic-uses@v1 # Need this because github context is not supported within step.uses (https://github.com/actions/runner/issues/895)
         with: 
         #   uses: uibcdf/action-build-and-upload-conda-packages@${{github.sha}}
           uses: uibcdf/action-build-and-upload-conda-packages@davide/conda_convert_dot_conda
-          with: >-
-            {
-                "meta_yaml_dir": ci/asyncio_recipe,
-                "upload": false,
-                "platform_all": true,
-                "conda_build_args": --package-format .conda
-            }
+          with: ${{ matrix.inputs }}
 
       - name: Verify outputs
         env:
-          EXPECTED_LENGTH: 13
-          EXPECTED_OUTPUTS: >-
-            linux-32/asyncio-3.4.1-py311_0.conda
-            linux-64/asyncio-3.4.1-py311_0.conda
-            linux-aarch64/asyncio-3.4.1-py311_0.conda
-            linux-armv6l/asyncio-3.4.1-py311_0.conda
-            linux-armv7l/asyncio-3.4.1-py311_0.conda
-            linux-ppc64/asyncio-3.4.1-py311_0.conda
-            linux-ppc64le/asyncio-3.4.1-py311_0.conda
-            linux-s390x/asyncio-3.4.1-py311_0.conda
-            osx-64/asyncio-3.4.1-py311_0.conda
-            osx-arm64/asyncio-3.4.1-py311_0.conda
-            win-32/asyncio-3.4.1-py311_0.conda
-            win-64/asyncio-3.4.1-py311_0.conda
-            win-arm64/asyncio-3.4.1-py311_0.conda
+          EXPECTED_NUM_OUTPUTS: ${{ matrix.expected_num_outputs }}
+          EXPECTED_OUTPUTS: ${{ matrix.expected_outputs }}
           OUTPUT_PATHS: ${{ fromJson(steps.test-action.outputs.outputs).paths }} # https://github.com/jenseng/dynamic-uses?tab=readme-ov-file#gotchaslimitations
         run: |
           # Remove the folder name from the path, only leaving the architecture folder (e.g. linux-64/package_name)
@@ -85,8 +92,8 @@ jobs:
           # Sort output paths alphabetically, to make the comparison easier
           output_paths=($(printf "%s\n" "${output_paths[@]}" | sort))
           n_outputs=${#output_paths[@]}
-          if [ $n_outputs != ${{ env.EXPECTED_LENGTH }} ]; then
-            echo "Wrong number of outputs: ${{ env.EXPECTED_LENGTH }} outputs expected, $n_outputs outputs found: [$(tr ' ' ', ' <<< ${output_paths[@]})]."
+          if [ $n_outputs != ${{ env.EXPECTED_NUM_OUTPUTS }} ]; then
+            echo "Wrong number of outputs: ${{ env.EXPECTED_NUM_OUTPUTS }} outputs expected, $n_outputs outputs found: [$(tr ' ' ', ' <<< ${output_paths[@]})]."
             exit 1
           fi
           if [[ "${output_paths[@]}" != "${{ env.EXPECTED_OUTPUTS }}" ]]; then

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,17 +34,17 @@ jobs:
   test-action:
     runs-on: ubuntu-latest
     needs: setup-conda-build
+    env:
+      COMMON_INPUTS: >-
+        "meta_yaml_dir": ci/asyncio_recipe,
+        "upload": false
     strategy:
       matrix:
         include:
-          - label: "Test: All platforms conversion, '.conda' package format"
+          - label: "Test: All platforms conversion, '.conda' package format."
             inputs: >-
-              {
-                "meta_yaml_dir": ci/asyncio_recipe,
-                "upload": false,
                 "platform_all": true,
                 "conda_build_args": --package-format .conda
-              }
             expected_num_outputs: 13
             expected_outputs: >-
               linux-32/asyncio-3.4.1-py311_0.conda
@@ -60,6 +60,19 @@ jobs:
               win-32/asyncio-3.4.1-py311_0.conda
               win-64/asyncio-3.4.1-py311_0.conda
               win-arm64/asyncio-3.4.1-py311_0.conda
+          - label: "Test: Specific platforms conversion, conda_convert_args, '.tar.bz2' package format."
+            inputs: >-
+                "platform_win-32": true,
+                "platform_win-64": true,
+                "platform_osx-64": true,
+                "conda_convert_args": --platform win-32,
+                "conda_build_args": --package-format .tar.bz2
+            expected_num_outputs: 4
+            expected_outputs: >-
+              linux-64/asyncio-3.4.1-py311_0.tar.bz2
+              osx-64/asyncio-3.4.1-py311_0.tar.bz2
+              win-32/asyncio-3.4.1-py311_0.tar.bz2
+              win-64/asyncio-3.4.1-py311_0.tar.bz2
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -77,7 +90,11 @@ jobs:
         with: 
         #   uses: uibcdf/action-build-and-upload-conda-packages@${{github.sha}}
           uses: uibcdf/action-build-and-upload-conda-packages@davide/conda_convert_dot_conda
-          with: ${{ matrix.inputs }}
+          with: >-
+            {
+              ${{ env.COMMON_INPUTS }},
+              ${{ matrix.inputs }}
+            }
 
       - name: Verify outputs
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+  workflow_dispatch:
+
+jobs:
+  test-action:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: 3.11
+          environment-file: ci/env.yml
+          miniconda-version: latest
+          auto-activate-base: false
+          auto-update-conda: false
+          show-channel-urls: true
+      - name: Test the action
+        id: test-action
+        uses: jenseng/dynamic-uses@v1 # Need this because github context is not supported within step.uses (https://github.com/actions/runner/issues/895)
+        with: 
+        #   uses: uibcdf/action-build-and-upload-conda-packages@${{github.sha}}
+          uses: uibcdf/action-build-and-upload-conda-packages@davide/conda_convert_dot_conda
+          with: >-
+            {
+                "meta_yaml_dir": ci/asyncio_recipe,
+                "upload": false,
+                "platform_all": true,
+                "conda_build_args": "--package-format 2"
+            }
+      - name: Verify outputs
+        env:
+          EXPECTED_LENGTH: 13
+          EXPECTED_OUTPUTS: >-
+            linux-32/asyncio-3.4.1-py311_0.conda
+            linux-64/asyncio-3.4.1-py311_0.conda
+            linux-aarch64/asyncio-3.4.1-py311_0.conda
+            linux-armv6l/asyncio-3.4.1-py311_0.conda
+            linux-armv7l/asyncio-3.4.1-py311_0.conda
+            linux-ppc64/asyncio-3.4.1-py311_0.conda
+            linux-ppc64le/asyncio-3.4.1-py311_0.conda
+            linux-s390x/asyncio-3.4.1-py311_0.conda
+            osx-64/asyncio-3.4.1-py311_0.conda
+            osx-arm64/asyncio-3.4.1-py311_0.conda
+            win-32/asyncio-3.4.1-py311_0.conda
+            win-64/asyncio-3.4.1-py311_0.conda
+            win-arm64/asyncio-3.4.1-py311_0.conda
+          OUTPUT_PATHS: ${{ fromJson(steps.test-action.outputs.outputs).paths }} # https://github.com/jenseng/dynamic-uses?tab=readme-ov-file#gotchaslimitations
+        run: |
+          # Remove the folder name from the path, only leaving the architecture folder (e.g. linux-64/package_name)
+          for path in ${{ env.OUTPUT_PATHS }}; do
+            output_paths+=($(sed -E 's|.*/([^/]+/[^/]+)$|\1|g' <<< $path))
+          done
+          # Sort output paths alphabetically, to make the comparison easier
+          output_paths=($(printf "%s\n" "${output_paths[@]}" | sort))
+          n_outputs=${#output_paths[@]}
+          if [ $n_outputs != ${{ env.EXPECTED_LENGTH }} ]; then
+            echo "Wrong number of outputs: ${{ env.EXPECTED_LENGTH }} outputs expected, $n_outputs outputs found: [$(tr ' ' ', ' <<< ${output_paths[@]})]."
+            exit 1
+          fi
+          if [[ "${output_paths[@]}" != "${{ env.EXPECTED_OUTPUTS }}" ]]; then
+            echo "Wrong outputs. Outputs expected: [$(tr ' ' ', ' <<< '${{ env.EXPECTED_OUTPUTS }}')], outputs found: [$(tr ' ' ', ' <<< ${output_paths[@]})]."
+            exit 1
+          fi
+
+

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,7 +45,6 @@ jobs:
             inputs: >-
                 "platform_all": true,
                 "conda_build_args": --package-format .conda
-            expected_num_outputs: 13
             expected_outputs: >-
               linux-32/asyncio-3.4.1-py311_0.conda
               linux-64/asyncio-3.4.1-py311_0.conda
@@ -67,7 +66,6 @@ jobs:
                 "platform_osx-64": true,
                 "conda_convert_args": --platform win-32,
                 "conda_build_args": --package-format .tar.bz2
-            expected_num_outputs: 4
             expected_outputs: >-
               linux-64/asyncio-3.4.1-py311_0.tar.bz2
               osx-64/asyncio-3.4.1-py311_0.tar.bz2
@@ -77,7 +75,6 @@ jobs:
             inputs: >-
                 "platform_host": false,
                 "anaconda_upload_args": --label mylabel
-            expected_num_outputs: 0
             expected_outputs: ""
     steps:
       - name: Check out repository
@@ -104,7 +101,6 @@ jobs:
 
       - name: Verify outputs
         env:
-          EXPECTED_NUM_OUTPUTS: ${{ matrix.expected_num_outputs }}
           EXPECTED_OUTPUTS: ${{ matrix.expected_outputs }}
           OUTPUT_PATHS: ${{ fromJson(steps.test-action.outputs.outputs).paths }} # https://github.com/jenseng/dynamic-uses?tab=readme-ov-file#gotchaslimitations
         run: |
@@ -114,11 +110,6 @@ jobs:
           done
           # Sort output paths alphabetically, to make the comparison easier
           output_paths=($(printf "%s\n" "${output_paths[@]}" | sort))
-          n_outputs=${#output_paths[@]}
-          if [ $n_outputs != ${{ env.EXPECTED_NUM_OUTPUTS }} ]; then
-            echo "Wrong number of outputs: ${{ env.EXPECTED_NUM_OUTPUTS }} outputs expected, $n_outputs outputs found: [$(tr ' ' ', ' <<< ${output_paths[@]})]."
-            exit 1
-          fi
           if [[ "${output_paths[@]}" != "${{ env.EXPECTED_OUTPUTS }}" ]]; then
             echo "Wrong outputs. Outputs expected: [$(tr ' ' ', ' <<< '${{ env.EXPECTED_OUTPUTS }}')], outputs found: [$(tr ' ' ', ' <<< ${output_paths[@]})]."
             exit 1

--- a/ci/asyncio_recipe/bld.bat
+++ b/ci/asyncio_recipe/bld.bat
@@ -1,0 +1,2 @@
+python setup.py install
+if errorlevel 1 exit 1

--- a/ci/asyncio_recipe/build.sh
+++ b/ci/asyncio_recipe/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+${PYTHON} setup.py install || exit 1;

--- a/ci/asyncio_recipe/meta.yaml
+++ b/ci/asyncio_recipe/meta.yaml
@@ -1,0 +1,30 @@
+
+package:
+    name: asyncio
+    version: 3.4.1
+
+source:
+    fn: asyncio-3.4.1.tar.gz
+    url: https://pypi.python.org/packages/source/a/asyncio/asyncio-3.4.1.tar.gz
+    md5: 7dc164ad37905ca3745576d0b9dfb2de
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+
+    run:
+        - python
+
+test:
+    imports:
+        - asyncio
+
+    #commands:
+    #    -
+
+about:
+    home: http://www.python.org/dev/peps/pep-3156/
+    license: Apache 2.0

--- a/ci/env.yml
+++ b/ci/env.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - nodefaults
+
+dependencies:
+  - anaconda-client
+  - conda-build

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,0 +1,8 @@
+name: test
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.11
+  - conda-build=25.1.2
+  - anaconda-client

--- a/test.yml
+++ b/test.yml
@@ -3,5 +3,5 @@ channels:
   - nodefaults
 
 dependencies:
-  - anaconda-client
-  - conda-build
+  - boa
+  - numpy


### PR DESCRIPTION
Fixes #26.

This is currently based on the `davide/conda_convert_dot_conda` branch. **Please review/merge only after #33, #34 and #35 have been merged ([more info](#more-info)).**


## Overview
This PR includes a CI workflow to test this action when a PR is (re)opened or synchronised, or when there are new pushes to `main`.
The workflow takes an example recipe and builds it using this action. It performs multiple tests by running multiple (parallel) jobs with different inputs (with a matrix strategy).

### Test Structure
Each test:
1. sets the correct environment (to enable `conda build`, `conda convert` and `anaconda upload` commands)
2. runs the action from the HEAD commit of the PR/branch that triggered the workflow, to verify that the action runs without failing
   <span id="more-info">**IMPORTANT**: Currently the action is run from the `davide/conda_convert_dot_conda` branch instead, because that is the branch with the state of the code up-to-date. It is only as an example to show that the workflow succeeds. After #33, #34 and #35 are merged, [this line](https://github.com/uibcdf/action-build-and-upload-conda-packages/blob/69e1c7e2c137596d20b1b743f44eac64cd503d74/.github/workflows/CI.yml#L95) should be deleted and [this line](https://github.com/uibcdf/action-build-and-upload-conda-packages/blob/69e1c7e2c137596d20b1b743f44eac64cd503d74/.github/workflows/CI.yml#L94) should be un-commented, before merging this PR.</span>
3. Checks that the action outputs match the expected outputs

### Example recipe
The chosen example recipe is the [asyncio recipe](https://github.com/conda-archive/conda-recipes/tree/main/python/asyncio) from the `conda-archive/conda-recipes` repo. It was not chosen for any particular reason, but it builds relatively quickly and is simple enough for our use-case.

### Example tests
The example tests try to cover different case, so as to test most of the input parameters and behaviours of the action.
Please leave a comment if you think there are some further important cases that are not currently tested but they should be added.

### Further test addition
Further tests can be added fairly easily, also for future needs.


