### PR TITLE
Automatic release workflow

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,52 @@
+name: CD
+
+on:
+  push:
+    tags: v[0-9]+.[0-9]+.[0-9]+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+
+      - name: Version sanity check
+        run: |
+          # Don't allow smaller or jumping versions in the MAJOR.MINOR.PATCH format
+          old_tag_name=$(git tag --list "v*" | tail -n2 | head -n1)
+          new_tag_name='${{ github.ref_name }}'
+          read -r old_major old_minor old_patch <<< $(echo $old_tag_name | cut -c 2- | tr '.' ' ')
+          read -r new_major new_minor new_patch <<< $(echo $new_tag_name | cut -c 2- | tr '.' ' ')
+          error_msg="Version tag inconsistent!\nVersion '$new_tag_name' cannot come after version '$new_tag_name' (latest released version)."
+          # Check MAJOR
+          if (( new_major < old_major || new_major > old_major + 1 )); then
+            echo -e "$msg"
+            exit 1
+          fi
+          # Check MINOR
+          if (( (new_major > old_major && new_minor != 0) || (new_minor > old_minor + 1) )); then
+            echo -e "$msg"
+            exit 1
+          fi
+          # Check PATCH
+          if (( (new_minor > old_minor && new_patch != 0) || (new_patch > old_patch + 1) )); then
+            echo -e "$msg"
+            exit 1
+          fi
+
+      - name: Create Release
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda #v2.2.1
+        with:
+          generate_release_notes: true
+          make_latest: true
+    
+      - name: Delete tag on failure
+        if: failure()
+        run: |
+          git push origin --delete ${{ github.ref_name }}
+          echo "The current workflow had an error. Tag '${{ github.ref_name }}' was deleted."

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -7,7 +7,10 @@ permissions:
   contents: write
 
 jobs:
-  create-release:
+  test-action:
+    uses: .github/workflows/test.yml
+    
+  version-sanity-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -38,6 +41,13 @@ jobs:
             echo -e "$msg"
             exit 1
           fi
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [version-sanity-check, test-action]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Create Release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda #v2.2.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: CD
+name: Release
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,24 +20,36 @@ jobs:
 
       - name: Version sanity check
         run: |
-          # Don't allow smaller or jumping versions in the MAJOR.MINOR.PATCH format
-          old_tag_name=$(git tag --list "v*" | tail -n2 | head -n1)
+          # Don't allow smaller new versions or jumping versions in the MAJOR.MINOR.PATCH format
+          old_tag_name=$(git tag --list --sort=-taggerdate | sed -n '2p')
+          if [ -z "$old_tag_name" ]; then
+            echo "No previous version found. Skipping version sanity check."
+            exit 0
+          fi
           new_tag_name='${{ github.ref_name }}'
-          read -r old_major old_minor old_patch <<< $(echo $old_tag_name | cut -c 2- | tr '.' ' ')
-          read -r new_major new_minor new_patch <<< $(echo $new_tag_name | cut -c 2- | tr '.' ' ')
+          read -r old_major old_minor old_patch <<< $(echo $old_tag_name | tr '.' ' ')
+          read -r new_major new_minor new_patch <<< $(echo $new_tag_name | tr '.' ' ')
           error_msg="Version tag inconsistent!\nVersion '$new_tag_name' cannot come after version '$new_tag_name' (latest released version)."
           # Check MAJOR
+          # - New major version cannot be smaller than previous 
+          # - Major version can only be incremented by 1 at a time
           if (( new_major < old_major || new_major > old_major + 1 )); then
             echo -e "$msg"
             exit 1
           fi
           # Check MINOR
-          if (( (new_major > old_major && new_minor != 0) || (new_minor > old_minor + 1) )); then
+          # - New minor version cannot be smaller than previous if major version is same
+          # - New minor version can only be 0 if major version is incremented
+          # - New minor version can only be incremented by 1 at a time
+          if (( (new_major == old_major && new_minor < old_minor) || (new_major > old_major && new_minor != 0) || (new_minor > old_minor + 1) )); then
             echo -e "$msg"
             exit 1
           fi
           # Check PATCH
-          if (( (new_minor > old_minor && new_patch != 0) || (new_patch > old_patch + 1) )); then
+          # - New patch version must be bigger than previous if minor version is same
+          # - New patch version can only be 0 if minor version is incremented
+          # - New patch version can only be incremented by 1 at a time
+          if (( (new_minor == old_minor && new_patch <= old_patch) || (new_minor > old_minor && new_patch != 0) || (new_patch > old_patch + 1) )); then
             echo -e "$msg"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   test-action:
-    uses: .github/workflows/test.yml
+    uses: ./.github/workflows/test.yml
     
   version-sanity-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,114 @@
+name: CI
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+  workflow_dispatch:
+  workflow_call:
+env:
+  CONDA_PKGS_DIRS: ~/conda_pkgs_dir
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  setup-conda-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+    
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: ci/environment.yml
+          cache-environment-key: environment-${{ hashFiles('ci/environment.yml') }}
+          cache-downloads-key: downloads-${{ hashFiles('ci/environment.yml') }}
+
+  test-action:
+    runs-on: ubuntu-latest
+    needs: setup-conda-build
+    env:
+      COMMON_INPUTS: >-
+        "meta_yaml_dir": ci/asyncio_recipe,
+        "upload": false
+    strategy:
+      matrix:
+        include:
+          - label: "Test: All platforms conversion, '.conda' package format."
+            inputs: >-
+                "platform_all": true,
+                "conda_build_args": --package-format .conda
+            expected_outputs: >-
+              linux-32/asyncio-3.4.1-py311_0.conda
+              linux-64/asyncio-3.4.1-py311_0.conda
+              linux-aarch64/asyncio-3.4.1-py311_0.conda
+              linux-armv6l/asyncio-3.4.1-py311_0.conda
+              linux-armv7l/asyncio-3.4.1-py311_0.conda
+              linux-ppc64/asyncio-3.4.1-py311_0.conda
+              linux-ppc64le/asyncio-3.4.1-py311_0.conda
+              linux-s390x/asyncio-3.4.1-py311_0.conda
+              osx-64/asyncio-3.4.1-py311_0.conda
+              osx-arm64/asyncio-3.4.1-py311_0.conda
+              win-32/asyncio-3.4.1-py311_0.conda
+              win-64/asyncio-3.4.1-py311_0.conda
+              win-arm64/asyncio-3.4.1-py311_0.conda
+          - label: "Test: Specific platforms conversion, conda_convert_args, '.tar.bz2' package format."
+            inputs: >-
+                "platform_win-32": true,
+                "platform_win-64": true,
+                "platform_osx-64": true,
+                "conda_convert_args": --platform win-32,
+                "conda_build_args": --package-format .tar.bz2
+            expected_outputs: >-
+              linux-64/asyncio-3.4.1-py311_0.tar.bz2
+              osx-64/asyncio-3.4.1-py311_0.tar.bz2
+              win-32/asyncio-3.4.1-py311_0.tar.bz2
+              win-64/asyncio-3.4.1-py311_0.tar.bz2
+          - label: "Test: Remove host platform, anaconda_upload_args."
+            inputs: >-
+                "platform_host": false,
+                "anaconda_upload_args": --label mylabel
+            expected_outputs: ""
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: ci/environment.yml
+          cache-environment-key: environment-${{ hashFiles('ci/environment.yml') }}
+          cache-downloads-key: downloads-${{ hashFiles('ci/environment.yml') }}
+
+      - name: ${{ matrix.label }}
+        id: test-action
+        uses: jenseng/dynamic-uses@v1 # Need this because github context is not supported within step.uses (https://github.com/actions/runner/issues/895)
+        with: 
+        #   uses: uibcdf/action-build-and-upload-conda-packages@${{github.sha}}
+          uses: uibcdf/action-build-and-upload-conda-packages@davide/conda_convert_dot_conda
+          with: >-
+            {
+              ${{ env.COMMON_INPUTS }},
+              ${{ matrix.inputs }}
+            }
+
+      - name: Verify outputs
+        env:
+          EXPECTED_OUTPUTS: ${{ matrix.expected_outputs }}
+          OUTPUT_PATHS: ${{ fromJson(steps.test-action.outputs.outputs).paths }} # https://github.com/jenseng/dynamic-uses?tab=readme-ov-file#gotchaslimitations
+        run: |
+          # Remove the folder name from the path, only leaving the architecture folder (e.g. linux-64/package_name)
+          for path in ${{ env.OUTPUT_PATHS }}; do
+            output_paths+=($(sed -E 's|.*/([^/]+/[^/]+)$|\1|g' <<< $path))
+          done
+          # Sort output paths alphabetically, to make the comparison easier
+          output_paths=($(printf "%s\n" "${output_paths[@]}" | sort))
+          if [[ "${output_paths[@]}" != "${{ env.EXPECTED_OUTPUTS }}" ]]; then
+            echo "Wrong outputs. Outputs expected: [$(tr ' ' ', ' <<< '${{ env.EXPECTED_OUTPUTS }}')], outputs found: [$(tr ' ' ', ' <<< ${output_paths[@]})]."
+            exit 1
+          fi
+
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,8 +87,7 @@ jobs:
         id: test-action
         uses: jenseng/dynamic-uses@v1 # Need this because github context is not supported within step.uses (https://github.com/actions/runner/issues/895)
         with: 
-        #   uses: uibcdf/action-build-and-upload-conda-packages@${{github.sha}}
-          uses: uibcdf/action-build-and-upload-conda-packages@davide/conda_convert_dot_conda
+          uses: uibcdf/action-build-and-upload-conda-packages@${{github.sha}}
           with: >-
             {
               ${{ env.COMMON_INPUTS }},


### PR DESCRIPTION
Fixes #22.

Set up a CD workflow that is triggered when a new tag (in the format `vMAJOR.MINOR.PATCH`) is pushed. 

The workflow:
- Checks that the version tag is consistent (no jumps and no smaller tags than the previous version)
- Tests the action using the `test.yml` workflow (renamed from the `CI.yml` workflow in #36)
- If these jobs are successful, creates a release with the pushed tag
- If any error is produced, the pushed tag is deleted.

Currently, this is a draft PR because it relies on the workflow in #36 and, therefore, it will be updated and marked as ready after the following PRs are merged:
- #33
- #34
- #35
- #36